### PR TITLE
Concrete var assign

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,12 +14,15 @@
 - [x] parsing tables
 - [x] Block params
 - [x] Ranges
+- [ ] Iteration (`each`) over tables
+- [ ] ctrl-c support
 - [ ] Column path
 - [ ] ...rest without calling it rest
 - [ ] operator overflow
 - [ ] finish operator type-checking
 - [ ] Source
 - [ ] Autoenv
+- [ ] Externals
 - [ ] let [first, rest] = [1, 2, 3]
   
 ## Maybe: 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -228,3 +228,11 @@ fn range_iteration2() -> TestResult {
 fn simple_value_iteration() -> TestResult {
     run_test("4 | each { $it + 10 }", "14")
 }
+
+#[test]
+fn concrete_variable_assignment() -> TestResult {
+    run_test(
+        "let x = (1..100 | each { |y| $y + 100 }); $x | length; $x | length",
+        "100",
+    )
+}


### PR DESCRIPTION
This will convert values to their "concrete" form when assigning to a variable. ValueStream -> List, RowStream -> Table.