### PR TITLE
Add cell paths

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,9 +14,9 @@
 - [x] parsing tables
 - [x] Block params
 - [x] Ranges
+- [x] Column path
 - [ ] Iteration (`each`) over tables
 - [ ] ctrl-c support
-- [ ] Column path
 - [ ] ...rest without calling it rest
 - [ ] operator overflow
 - [ ] finish operator type-checking

--- a/crates/nu-cli/src/errors.rs
+++ b/crates/nu-cli/src/errors.rs
@@ -328,6 +328,40 @@ pub fn report_shell_error(
                         Label::primary(diag_file_id, diag_range).with_message("division by zero")
                     ])
             }
+            ShellError::AccessBeyondEnd(len, span) => {
+                let (diag_file_id, diag_range) = convert_span_to_diag(working_set, span)?;
+
+                Diagnostic::error()
+                    .with_message("Row number too large")
+                    .with_labels(vec![Label::primary(diag_file_id, diag_range)
+                        .with_message(format!("row number too large (max: {})", *len))])
+            }
+            ShellError::AccessBeyondEndOfStream(span) => {
+                let (diag_file_id, diag_range) = convert_span_to_diag(working_set, span)?;
+
+                Diagnostic::error()
+                    .with_message("Row number too large")
+                    .with_labels(vec![Label::primary(diag_file_id, diag_range)
+                        .with_message("row number too large")])
+            }
+            ShellError::IncompatiblePathAccess(name, span) => {
+                let (diag_file_id, diag_range) = convert_span_to_diag(working_set, span)?;
+
+                Diagnostic::error()
+                    .with_message("Data cannot be accessed with a column path")
+                    .with_labels(vec![Label::primary(diag_file_id, diag_range)
+                        .with_message(format!("{} doesn't support column paths", name))])
+            }
+            ShellError::CantFindColumn(span) => {
+                let (diag_file_id, diag_range) = convert_span_to_diag(working_set, span)?;
+
+                //FIXME: add "did you mean"
+                Diagnostic::error()
+                    .with_message("Cannot find column")
+                    .with_labels(vec![
+                        Label::primary(diag_file_id, diag_range).with_message("cannot find column")
+                    ])
+            }
         };
 
     // println!("DIAG");

--- a/crates/nu-engine/src/eval.rs
+++ b/crates/nu-engine/src/eval.rs
@@ -102,6 +102,11 @@ pub fn eval_expression(
         Expr::Var(var_id) => context
             .get_var(*var_id)
             .map_err(move |_| ShellError::VariableNotFoundAtRuntime(expr.span)),
+        Expr::FullCellPath(column_path) => {
+            let value = eval_expression(context, &column_path.head)?;
+
+            value.follow_column_path(&column_path.tail)
+        }
         Expr::Call(call) => eval_call(context, call, Value::nothing()),
         Expr::ExternalCall(_, _) => Err(ShellError::ExternalNotSupported(expr.span)),
         Expr::Operator(_) => Ok(Value::Nothing { span: expr.span }),

--- a/crates/nu-parser/src/flatten.rs
+++ b/crates/nu-parser/src/flatten.rs
@@ -1,4 +1,4 @@
-use nu_protocol::ast::{Block, Expr, Expression, Pipeline, Statement};
+use nu_protocol::ast::{Block, Expr, Expression, PathMember, Pipeline, Statement};
 use nu_protocol::{engine::StateWorkingSet, Span};
 
 #[derive(Debug)]
@@ -66,6 +66,17 @@ pub fn flatten_expression(
         }
         Expr::Float(_) => {
             vec![(expr.span, FlatShape::Float)]
+        }
+        Expr::FullCellPath(column_path) => {
+            let mut output = vec![];
+            output.extend(flatten_expression(working_set, &column_path.head));
+            for path_element in &column_path.tail {
+                match path_element {
+                    PathMember::String { span, .. } => output.push((*span, FlatShape::String)),
+                    PathMember::Int { span, .. } => output.push((*span, FlatShape::Int)),
+                }
+            }
+            output
         }
         Expr::Range(from, to, op) => {
             let mut output = vec![];

--- a/crates/nu-protocol/src/ast/cell_path.rs
+++ b/crates/nu-protocol/src/ast/cell_path.rs
@@ -1,0 +1,19 @@
+use super::Expression;
+use crate::Span;
+
+#[derive(Debug, Clone)]
+pub enum PathMember {
+    String { val: String, span: Span },
+    Int { val: usize, span: Span },
+}
+
+#[derive(Debug, Clone)]
+pub struct CellPath {
+    pub members: Vec<PathMember>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FullCellPath {
+    pub head: Expression,
+    pub tail: Vec<PathMember>,
+}

--- a/crates/nu-protocol/src/ast/expr.rs
+++ b/crates/nu-protocol/src/ast/expr.rs
@@ -1,4 +1,4 @@
-use super::{Call, Expression, Operator, RangeOperator};
+use super::{Call, Expression, FullCellPath, Operator, RangeOperator};
 use crate::{BlockId, Signature, Span, VarId};
 
 #[derive(Debug, Clone)]
@@ -22,6 +22,7 @@ pub enum Expr {
     Table(Vec<Expression>, Vec<Vec<Expression>>),
     Keyword(Vec<u8>, Span, Box<Expression>),
     String(String), // FIXME: improve this in the future?
+    FullCellPath(Box<FullCellPath>),
     Signature(Box<Signature>),
     Garbage,
 }

--- a/crates/nu-protocol/src/ast/mod.rs
+++ b/crates/nu-protocol/src/ast/mod.rs
@@ -1,5 +1,6 @@
 mod block;
 mod call;
+mod cell_path;
 mod expr;
 mod expression;
 mod operator;
@@ -8,6 +9,7 @@ mod statement;
 
 pub use block::*;
 pub use call::*;
+pub use cell_path::*;
 pub use expr::*;
 pub use expression::*;
 pub use operator::*;

--- a/crates/nu-protocol/src/shell_error.rs
+++ b/crates/nu-protocol/src/shell_error.rs
@@ -17,4 +17,8 @@ pub enum ShellError {
     CantConvert(String, Span),
     DivisionByZero(Span),
     CannotCreateRange(Span),
+    AccessBeyondEnd(usize, Span),
+    AccessBeyondEndOfStream(Span),
+    IncompatiblePathAccess(String, Span),
+    CantFindColumn(Span),
 }

--- a/crates/nu-protocol/src/syntax_shape.rs
+++ b/crates/nu-protocol/src/syntax_shape.rs
@@ -13,10 +13,10 @@ pub enum SyntaxShape {
     String,
 
     /// A dotted path to navigate the table
-    ColumnPath,
+    CellPath,
 
     /// A dotted path to navigate the table (including variable)
-    FullColumnPath,
+    FullCellPath,
 
     /// Only a numeric (integer or decimal) value is allowed
     Number,
@@ -76,12 +76,12 @@ impl SyntaxShape {
         match self {
             SyntaxShape::Any => Type::Unknown,
             SyntaxShape::Block => Type::Block,
-            SyntaxShape::ColumnPath => Type::Unknown,
+            SyntaxShape::CellPath => Type::Unknown,
             SyntaxShape::Duration => Type::Duration,
             SyntaxShape::Expression => Type::Unknown,
             SyntaxShape::FilePath => Type::FilePath,
             SyntaxShape::Filesize => Type::Filesize,
-            SyntaxShape::FullColumnPath => Type::Unknown,
+            SyntaxShape::FullCellPath => Type::Unknown,
             SyntaxShape::GlobPattern => Type::String,
             SyntaxShape::Int => Type::Int,
             SyntaxShape::List(x) => {

--- a/crates/nu-protocol/src/ty.rs
+++ b/crates/nu-protocol/src/ty.rs
@@ -8,7 +8,7 @@ pub enum Type {
     Bool,
     String,
     Block,
-    ColumnPath,
+    CellPath,
     Duration,
     FilePath,
     Filesize,
@@ -27,7 +27,7 @@ impl Display for Type {
         match self {
             Type::Block => write!(f, "block"),
             Type::Bool => write!(f, "bool"),
-            Type::ColumnPath => write!(f, "column path"),
+            Type::CellPath => write!(f, "cell path"),
             Type::Duration => write!(f, "duration"),
             Type::FilePath => write!(f, "filepath"),
             Type::Filesize => write!(f, "filesize"),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -254,3 +254,23 @@ fn build_string3() -> TestResult {
         "nushell rocks",
     )
 }
+
+#[test]
+fn cell_path_subexpr1() -> TestResult {
+    run_test("([[lang, gems]; [nu, 100]]).lang", "[nu]")
+}
+
+#[test]
+fn cell_path_subexpr2() -> TestResult {
+    run_test("([[lang, gems]; [nu, 100]]).lang.0", "nu")
+}
+
+#[test]
+fn cell_path_var1() -> TestResult {
+    run_test("let x = [[lang, gems]; [nu, 100]]; $x.lang", "[nu]")
+}
+
+#[test]
+fn cell_path_var2() -> TestResult {
+    run_test("let x = [[lang, gems]; [nu, 100]]; $x.lang.0", "nu")
+}


### PR DESCRIPTION
Adds cell paths for variables and subexpressions.

These allow you to access data in rows, columns, and cells of lists, tables, value streams, and row streams.

Eg)

```
> ([[a b]; [[1 2] [3 4]]]).a
[[1, 2]]

> ([[a b]; [[1 2] [3 4]]]).a.0
[1, 2]

> ([[a b]; [[1 2] [3 4]]]).a.0.1
2
```